### PR TITLE
Add speaker notes support

### DIFF
--- a/AI-instructions.md
+++ b/AI-instructions.md
@@ -64,6 +64,68 @@ slides/
 
 5. **Add to index.html**: Add a corresponding empty section tag `<section id="productDemo"></section>` and update the `slideIds` array.
 
+### Working with Speaker Notes
+
+Speaker notes are private notes visible only to the presenter in speaker view. They help provide context, talking points, and additional information without cluttering the slide for the audience.
+
+1. **Adding Speaker Notes to a Slide**:
+   
+   Add an `<aside>` element with the class `notes` within your slide's HTML template:
+   
+   ```javascript
+   export const html = `
+     <h2>Slide Title</h2>
+     <ul>
+       <li>Point 1</li>
+       <li>Point 2</li>
+       <li>Point 3</li>
+     </ul>
+     
+     <aside class="notes">
+       This slide covers the key aspects of our approach.
+       - Emphasize the importance of Point 2
+       - If there are questions about Point 3, mention that we'll cover this in detail later
+       - This information is only visible to the presenter
+     </aside>
+   `;
+   ```
+
+2. **Enabling Speaker Mode**:
+   
+   Speaker mode requires the notes plugin to be enabled in the index.html file. Make sure the following additions are present:
+   
+   ```html
+   <!-- Load Reveal.js plugins -->
+   <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.3.1/plugin/notes/notes.js"></script>
+   
+   <script>
+     Reveal.initialize({
+       // Other options...
+       plugins: [ RevealNotes ]
+     });
+   </script>
+   ```
+
+3. **Using Speaker View**:
+   
+   To access speaker view during a presentation:
+   - Press the **S** key on the keyboard
+   - A new window will open with speaker view
+   - The speaker view shows:
+     - Current slide
+     - Next slide preview
+     - Speaker notes
+     - Timer
+     - Current time
+
+4. **Best Practices for Speaker Notes**:
+   
+   - Keep notes concise and focused on key talking points
+   - Include reminders for transitions or demos
+   - Add context that doesn't belong on the main slide
+   - Note potential questions and prepared answers
+   - Include timing guidelines for complex sections
+
 ### Modifying Existing Slides
 
 1. **Identify the correct module**: Find the right `.js` file in the `slides/js/slides/` directory.
@@ -241,6 +303,14 @@ export const html = `
     <li>Approach: [Brief methodology]</li>
     <li>Key findings: [Major results]</li>
   </ul>
+
+  <aside class="notes">
+    Welcome everyone to this presentation. 
+    Key points to emphasize:
+    - Our innovative approach differentiates us from competitors
+    - The methodology has been rigorously validated
+    - Findings show a 35% improvement over baseline
+  </aside>
 `;
 
 export function initialize() {
@@ -260,6 +330,13 @@ export const html = `
   <div class="chart-container" style="height: 400px; width: 80%; margin: 0 auto;">
     <canvas id="resultsChart"></canvas>
   </div>
+
+  <aside class="notes">
+    This chart shows our primary results:
+    - Notice the clear trend in Category B
+    - If asked about outliers, explain that they were validated in follow-up experiments
+    - Remind audience that detailed analysis is available in the appendix
+  </aside>
 `;
 
 export function initialize() {
@@ -328,6 +405,14 @@ def analyze_data(dataset):
         }
     return results
   </code></pre>
+
+  <aside class="notes">
+    This is the core analysis function:
+    - Highlight the efficient iteration over features
+    - The dictionary structure makes results easy to access
+    - Note that this approach scales linearly with the number of features
+    - If asked about performance, mention optimizations are in the roadmap
+  </aside>
 `;
 
 export function initialize() {
@@ -355,4 +440,5 @@ python -m http.server
 # Or using Node.js http-server
 npx http-server
 ```
-3. Open a browser and go to http://localhost:8000/slides/ to view the presentation 
+3. Open a browser and go to http://localhost:8000/slides/ to view the presentation
+4. Press 'S' during the presentation to open speaker view with notes 

--- a/index.html
+++ b/index.html
@@ -97,6 +97,9 @@
   <!-- Load Reveal.js -->
   <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.3.1/dist/reveal.js"></script>
   
+  <!-- Load Reveal.js plugins -->
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.3.1/plugin/notes/notes.js"></script>
+  
   <!-- Load slide modules and initialize presentation -->
   <script type="module">
     import { 
@@ -119,7 +122,8 @@
       center: true,
       history: true,
       minScale: 0.2,
-      maxScale: 2.0
+      maxScale: 2.0,
+      plugins: [ RevealNotes ]
     });
     
     // Preload all slides

--- a/js/slides/slide1.js
+++ b/js/slides/slide1.js
@@ -14,14 +14,40 @@ export const html = `
       <li>Modular architecture for better AI context management</li>
     </ul>
   </div>
+
+  <div class="fragment fade-up" style="margin-top: 30px; display: inline-block; background-color: rgba(66, 133, 244, 0.1); border-left: 4px solid var(--highlight-color); padding: 8px 15px; border-radius: 0 4px 4px 0; animation: pulse 2s infinite;">
+    <p style="margin: 0; font-size: 0.8em;">💡 Press <kbd style="background-color: #f8f9fa; border: 1px solid #ddd; border-radius: 3px; padding: 2px 5px; font-family: monospace;">S</kbd> to open speaker view</p>
+  </div>
+
+  <aside class="notes">
+    This opening slide introduces our core design philosophy. Emphasize how we've flipped traditional presentation design on its head by making AI-generation the primary use case rather than human authoring. Point out that while this approach requires more technical knowledge, it results in more predictable and maintainable presentations. The modular architecture is especially valuable when working with AI tools that benefit from well-defined context boundaries.
+  </aside>
 `;
 
 // Initialization function - no special initialization needed for this simple slide
 export function initialize() {
   console.log('Slide 1 initialized');
+  
+  // Add keyframe animation for pulsing effect
+  const style = document.createElement('style');
+  style.id = 'slide1-animation-style';
+  style.textContent = `
+    @keyframes pulse {
+      0% { transform: scale(1); }
+      50% { transform: scale(1.05); }
+      100% { transform: scale(1); }
+    }
+  `;
+  document.head.appendChild(style);
 }
 
 // Cleanup function - no special cleanup needed for this simple slide
 export function cleanup() {
   console.log('Slide 1 cleaned up');
+  
+  // Remove the added style element
+  const styleElement = document.getElementById('slide1-animation-style');
+  if (styleElement) {
+    styleElement.remove();
+  }
 } 

--- a/js/slides/slide2.js
+++ b/js/slides/slide2.js
@@ -18,6 +18,10 @@ export const html = `
       Highlight Key Points
     </button>
   </div>
+
+  <aside class="notes">
+    This slide demonstrates the interactive highlight feature while explaining our architectural principles. When presenting, click the button to cycle through the key points. Each point represents a core architectural decision that makes this framework AI-optimized. The independent modules provide scope isolation, preventing variables from bleeding across slides. The explicit lifecycle hooks ensure proper resource management. The technical approach prioritizes predictability and consistency over simplicity, which is critical for AI-generated content.
+  </aside>
 `;
 
 // Current highlight index

--- a/js/slides/slide3.js
+++ b/js/slides/slide3.js
@@ -31,6 +31,10 @@ export const html = `
   <div class="fragment" style="margin-top: 30px; padding: 15px; background-color: #f8f9fa; border-radius: 8px; border-left: 4px solid #4a86e8;">
     <p>Experience this framework and contribute at: <a href="https://github.com/grapeot/cursor_slides" target="_blank">https://github.com/grapeot/cursor_slides</a></p>
   </div>
+
+  <aside class="notes">
+    This slide explains the key benefits of using JavaScript modules over traditional HTML files for presentations. Emphasize the isolation benefits - both for human developers and AI assistants. The modular approach allows for better error containment and more manageable code. When discussing, highlight how the initialize() and cleanup() hooks provide clean lifecycle management.
+  </aside>
 `;
 
 // Initialization function

--- a/js/slides/slide4.js
+++ b/js/slides/slide4.js
@@ -16,6 +16,10 @@ export const html = `
       Update Data
     </button>
   </div>
+
+  <aside class="notes">
+    This slide showcases how we can integrate powerful data visualization libraries like Chart.js into our presentation framework. The chart displays two datasets with a smooth line visualization. During the presentation, click the "Update Data" button to demonstrate how the chart can be dynamically updated with new random values. This illustrates how our framework can handle complex third-party libraries and interactive elements while maintaining proper initialization and cleanup. Note how the slide module properly manages the chart instance lifecycle.
+  </aside>
 `;
 
 // Chart instance

--- a/js/slides/slide5.js
+++ b/js/slides/slide5.js
@@ -21,6 +21,10 @@ export const html = `
       Toggle Rotation
     </button>
   </div>
+
+  <aside class="notes">
+    This slide demonstrates integrating advanced 3D graphics using Three.js. The cube has different colored faces and rotates automatically. During the presentation, interact with the 3D cube by dragging to rotate the view with your mouse. Use the "Reset View" button to return to the original camera position, and the "Toggle Rotation" button to pause or resume the cube's rotation. This example shows how our modular framework can handle complex WebGL content while properly managing resources and event listeners. Note the comprehensive cleanup function that prevents memory leaks.
+  </aside>
 `;
 
 // Three.js components

--- a/js/slides/slide6.js
+++ b/js/slides/slide6.js
@@ -16,6 +16,10 @@ export const html = `
       </marker>
     </defs>
   </svg>
+
+  <aside class="notes">
+    This slide demonstrates a dynamic flowchart created with JavaScript. Point out how the chart automatically adjusts to the window size and how the nodes are connected with directional arrows. This is a good example of how JavaScript can create interactive diagrams that would be difficult to implement with static HTML. The flowchart shows a simple process flow with branching paths that converge back to a single path.
+  </aside>
 `;
 
 // Initialize function


### PR DESCRIPTION
This PR adds support for speaker notes to SlidePilot. Changes include: added RevealNotes plugin to index.html, added speaker notes to all example slides, updated documentation, and added visual reminder to press 'S' to open speaker view.